### PR TITLE
Feat/header

### DIFF
--- a/src/components/FeedPage.vue
+++ b/src/components/FeedPage.vue
@@ -1,39 +1,22 @@
 <template>
   <div class="feed-page">
     <!-- Header -->
-    <header class="header">
-      <div class="header-container">
-        <h1 class="logo" @click="$emit('navigate', 'feed')">Picstory</h1>
-        <div class="search-container">
-          <input 
-            type="search" 
-            placeholder="검색..." 
-            v-model="searchQuery"
-            class="search-input"
-          >
-          <svg class="search-icon" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M21 21l-6-6m2-5a7 7 0 11-14 0 7 7 0 0114 0z"></path>
-          </svg>
-        </div>
-        <div class="nav-buttons">
-          <button @click="$emit('navigate', 'gallery')" class="nav-btn">Gallery</button>
-          <button @click="$emit('navigate', 'profile')" class="profile-btn">
-            <img src="https://placehold.co/40x40/334155/FFFFFF?text=Me" class="profile-img" alt="Profile">
-          </button>
-        </div>
-      </div>
-    </header>
+    <AppHeader
+      :currentPage="'feed'"
+      @navigate="handleNavigate"
+      @search="handleSearch"
+    />
 
     <!-- Photo Grid -->
     <main class="main-content">
       <div class="photo-grid">
-        <div 
-          v-for="(image, index) in images" 
+        <div
+          v-for="(image, index) in images"
           :key="index"
           class="photo-item"
           @click="openImage(image, index)"
         >
-          <img :src="image.src" :alt="image.alt" class="photo">
+          <img :src="image.src" :alt="image.alt" class="photo" />
           <div class="photo-overlay">
             <div class="photo-info">
               <h3>{{ image.title }}</h3>
@@ -47,252 +30,159 @@
 </template>
 
 <script>
-export default {
-  name: 'FeedPage',
-  data() {
-    return {
-      searchQuery: '',
-      images: [
-        {
-          src: 'https://images.unsplash.com/photo-1506744038136-46273834b3fb?q=80&w=2070',
-          alt: '풍경 사진',
-          title: 'Mountain Vista',
-          author: 'John Doe'
-        },
-        {
-          src: 'https://images.unsplash.com/photo-1532274402911-5a369e4c4bb5?q=80&w=2070',
-          alt: '호수 사진',
-          title: 'Serene Lake',
-          author: 'Jane Smith'
-        },
-        {
-          src: 'https://images.unsplash.com/photo-1470770841072-f978cf4d019e?q=80&w=2070',
-          alt: '숲 사진',
-          title: 'Forest Path',
-          author: 'Mike Johnson'
-        },
-        {
-          src: 'https://images.unsplash.com/photo-1433086966358-54859d0ed716?q=80&w=1974',
-          alt: '폭포 사진',
-          title: 'Waterfall',
-          author: 'Sarah Wilson'
-        },
-        {
-          src: 'https://images.unsplash.com/photo-1447752875215-b2761acb3c5d?q=80&w=2070',
-          alt: '강 사진',
-          title: 'River Flow',
-          author: 'David Brown'
-        },
-        {
-          src: 'https://images.unsplash.com/photo-1501854140801-50d01698950b?q=80&w=2175',
-          alt: '초원 사진',
-          title: 'Green Fields',
-          author: 'Emily Davis'
-        },
-        {
-          src: 'https://images.unsplash.com/photo-1469474968028-56623f02e42e?q=80&w=2074',
-          alt: '산맥 사진',
-          title: 'Mountain Range',
-          author: 'Chris Lee'
-        },
-        {
-          src: 'https://images.unsplash.com/photo-1505144808419-1957a94ca61e?q=80&w=1974',
-          alt: '해변 사진',
-          title: 'Ocean Waves',
-          author: 'Lisa Garcia'
-        }
-      ]
-    }
-  },
-  methods: {
-    openImage(image, index) {
-      this.$emit('openModal', image, this.images, index)
+  import AppHeader from './Header.vue'
+
+  export default {
+    name: 'FeedPage',
+    components: {
+      AppHeader
+    },
+    data() {
+      return {
+        images: [
+          {
+            src: 'https://images.unsplash.com/photo-1506744038136-46273834b3fb?q=80&w=2070',
+            alt: '풍경 사진',
+            title: 'Mountain Vista',
+            author: 'John Doe'
+          },
+          {
+            src: 'https://images.unsplash.com/photo-1532274402911-5a369e4c4bb5?q=80&w=2070',
+            alt: '호수 사진',
+            title: 'Serene Lake',
+            author: 'Jane Smith'
+          },
+          {
+            src: 'https://images.unsplash.com/photo-1470770841072-f978cf4d019e?q=80&w=2070',
+            alt: '숲 사진',
+            title: 'Forest Path',
+            author: 'Mike Johnson'
+          },
+          {
+            src: 'https://images.unsplash.com/photo-1433086966358-54859d0ed716?q=80&w=1974',
+            alt: '폭포 사진',
+            title: 'Waterfall',
+            author: 'Sarah Wilson'
+          },
+          {
+            src: 'https://images.unsplash.com/photo-1447752875215-b2761acb3c5d?q=80&w=2070',
+            alt: '강 사진',
+            title: 'River Flow',
+            author: 'David Brown'
+          },
+          {
+            src: 'https://images.unsplash.com/photo-1501854140801-50d01698950b?q=80&w=2175',
+            alt: '초원 사진',
+            title: 'Green Fields',
+            author: 'Emily Davis'
+          },
+          {
+            src: 'https://images.unsplash.com/photo-1469474968028-56623f02e42e?q=80&w=2074',
+            alt: '산맥 사진',
+            title: 'Mountain Range',
+            author: 'Chris Lee'
+          },
+          {
+            src: 'https://images.unsplash.com/photo-1505144808419-1957a94ca61e?q=80&w=1974',
+            alt: '해변 사진',
+            title: 'Ocean Waves',
+            author: 'Lisa Garcia'
+          }
+        ]
+      }
+    },
+    methods: {
+      openImage(image, index) {
+        this.$emit('openModal', image, this.images, index)
+      },
+      handleNavigate(page) {
+        this.$emit('navigate', page)
+      },
+      handleSearch(query) {
+        // 검색 로직 구현
+        console.log('Search query:', query)
+      }
     }
   }
-}
 </script>
 
 <style scoped>
-.feed-page {
-  min-height: 100vh;
-  background-color: #111827;
-}
+  .feed-page {
+    min-height: 100vh;
+    background-color: #111827;
+  }
 
-.header {
-  position: sticky;
-  top: 0;
-  background-color: rgba(17, 24, 39, 0.8);
-  backdrop-filter: blur(16px);
-  z-index: 20;
-  border-bottom: 1px solid #374151;
-}
+  .main-content {
+    max-width: 1200px;
+    margin: 0 auto;
+    padding: 1rem;
+  }
 
-.header-container {
-  max-width: 1200px;
-  margin: 0 auto;
-  padding: 0.75rem 1rem;
-  display: flex;
-  justify-content: space-between;
-  align-items: center;
-}
-
-.logo {
-  font-size: 1.5rem;
-  font-weight: bold;
-  color: #f59e0b;
-  font-family: 'Times New Roman', serif;
-  cursor: pointer;
-}
-
-.search-container {
-  position: relative;
-  width: 100%;
-  max-width: 24rem;
-}
-
-.search-input {
-  width: 100%;
-  padding: 0.5rem 0.75rem 0.5rem 2.5rem;
-  background-color: #1f2937;
-  border-radius: 9999px;
-  color: white;
-  border: none;
-}
-
-.search-input::placeholder {
-  color: #6b7280;
-}
-
-.search-input:focus {
-  outline: none;
-  box-shadow: 0 0 0 2px #f59e0b;
-}
-
-.search-icon {
-  width: 1.25rem;
-  height: 1.25rem;
-  position: absolute;
-  left: 0.75rem;
-  top: 50%;
-  transform: translateY(-50%);
-  color: #6b7280;
-}
-
-.nav-buttons {
-  display: flex;
-  align-items: center;
-  gap: 1rem;
-}
-
-.nav-btn {
-  color: #d1d5db;
-  background: none;
-  border: none;
-  cursor: pointer;
-  transition: color 0.3s ease;
-}
-
-.nav-btn:hover {
-  color: #f59e0b;
-}
-
-.profile-btn {
-  background: none;
-  border: none;
-  cursor: pointer;
-}
-
-.profile-img {
-  width: 2.5rem;
-  height: 2.5rem;
-  border-radius: 50%;
-  border: 2px solid #f59e0b;
-}
-
-.main-content {
-  max-width: 1200px;
-  margin: 0 auto;
-  padding: 1rem;
-}
-
-.photo-grid {
-  display: grid;
-  grid-template-columns: repeat(auto-fill, minmax(250px, 1fr));
-  gap: 1rem;
-}
-
-.photo-item {
-  position: relative;
-  cursor: pointer;
-  border-radius: 0.5rem;
-  overflow: hidden;
-  transition: transform 0.3s ease;
-}
-
-.photo-item:hover {
-  transform: scale(1.02);
-}
-
-.photo {
-  width: 100%;
-  height: 300px;
-  object-fit: cover;
-  transition: opacity 0.3s ease;
-}
-
-.photo-item:hover .photo {
-  opacity: 0.7;
-}
-
-.photo-overlay {
-  position: absolute;
-  inset: 0;
-  background: rgba(0, 0, 0, 0.4);
-  opacity: 0;
-  transition: opacity 0.3s ease;
-  display: flex;
-  align-items: flex-end;
-  padding: 1rem;
-}
-
-.photo-item:hover .photo-overlay {
-  opacity: 1;
-}
-
-.photo-info {
-  color: white;
-}
-
-.photo-info h3 {
-  font-weight: bold;
-  margin-bottom: 0.25rem;
-}
-
-.photo-info p {
-  font-size: 0.875rem;
-  color: #d1d5db;
-}
-
-@media (max-width: 768px) {
-  .header-container {
-    flex-direction: column;
+  .photo-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fill, minmax(250px, 1fr));
     gap: 1rem;
   }
-  
-  .search-container {
-    order: 2;
+
+  .photo-item {
+    position: relative;
+    cursor: pointer;
+    border-radius: 0.5rem;
+    overflow: hidden;
+    transition: transform 0.3s ease;
   }
-  
-  .nav-buttons {
-    order: 1;
+
+  .photo-item:hover {
+    transform: scale(1.02);
   }
-  
-  .photo-grid {
-    grid-template-columns: repeat(auto-fill, minmax(200px, 1fr));
-  }
-  
+
   .photo {
-    height: 200px;
+    width: 100%;
+    height: 300px;
+    object-fit: cover;
+    transition: opacity 0.3s ease;
   }
-}
+
+  .photo-item:hover .photo {
+    opacity: 0.7;
+  }
+
+  .photo-overlay {
+    position: absolute;
+    inset: 0;
+    background: rgba(0, 0, 0, 0.4);
+    opacity: 0;
+    transition: opacity 0.3s ease;
+    display: flex;
+    align-items: flex-end;
+    padding: 1rem;
+  }
+
+  .photo-item:hover .photo-overlay {
+    opacity: 1;
+  }
+
+  .photo-info {
+    color: white;
+  }
+
+  .photo-info h3 {
+    font-weight: bold;
+    margin-bottom: 0.25rem;
+  }
+
+  .photo-info p {
+    font-size: 0.875rem;
+    color: #d1d5db;
+  }
+
+  @media (max-width: 768px) {
+    .photo-grid {
+      grid-template-columns: repeat(auto-fill, minmax(200px, 1fr));
+    }
+
+    .photo {
+      height: 200px;
+    }
+  }
 </style>

--- a/src/components/FeedPage.vue
+++ b/src/components/FeedPage.vue
@@ -2,7 +2,7 @@
   <div class="feed-page">
     <!-- Header -->
     <AppHeader
-      :currentPage="'feed'"
+      currentPage="feed"
       @navigate="handleNavigate"
       @search="handleSearch"
     />

--- a/src/components/GalleryPage.vue
+++ b/src/components/GalleryPage.vue
@@ -1,28 +1,11 @@
 <template>
   <div class="gallery-page">
     <!-- Header -->
-    <header class="header">
-      <div class="header-container">
-        <button @click="$emit('navigate', 'feed')" class="logo">Picstory</button>
-        <div class="search-container">
-          <input 
-            type="search" 
-            placeholder="검색..." 
-            v-model="searchQuery"
-            class="search-input"
-          >
-          <svg class="search-icon" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M21 21l-6-6m2-5a7 7 0 11-14 0 7 7 0 0114 0z"></path>
-          </svg>
-        </div>
-        <div class="nav-buttons">
-          <button @click="$emit('navigate', 'gallery')" class="nav-btn active">Gallery</button>
-          <button @click="$emit('navigate', 'profile')" class="profile-btn">
-            <img src="https://placehold.co/40x40/334155/FFFFFF?text=Me" class="profile-img" alt="Profile">
-          </button>
-        </div>
-      </div>
-    </header>
+    <AppHeader
+      :currentPage="'gallery'"
+      @navigate="handleNavigate"
+      @search="handleSearch"
+    />
 
     <main class="main-content">
       <div class="gallery-intro">
@@ -31,13 +14,13 @@
       </div>
 
       <!-- Gallery Items -->
-      <div 
-        v-for="(item, index) in galleryItems" 
+      <div
+        v-for="(item, index) in galleryItems"
         :key="index"
         class="gallery-item"
       >
         <div class="gallery-image">
-          <img :src="item.image" :alt="item.title" class="gallery-photo">
+          <img :src="item.image" :alt="item.title" class="gallery-photo" />
         </div>
         <div class="gallery-content">
           <h3 class="item-title">{{ item.title }}</h3>
@@ -45,16 +28,34 @@
           <p class="item-description">{{ item.description }}</p>
           <div class="item-stats">
             <div class="stat">
-              <svg class="stat-icon" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor">
+              <svg
+                class="stat-icon"
+                xmlns="http://www.w3.org/2000/svg"
+                viewBox="0 0 20 20"
+                fill="currentColor"
+              >
                 <path d="M10 12.5a2.5 2.5 0 100-5 2.5 2.5 0 000 5z" />
-                <path fill-rule="evenodd" d="M.664 10.59a1.651 1.651 0 010-1.18l.879-1.528A1.65 1.65 0 013.437 7h13.126c1.062 0 1.92.714 2.248 1.754l.879 1.528a1.651 1.651 0 010 1.18l-.879 1.528A1.65 1.65 0 0116.563 13H3.437a1.65 1.65 0 01-1.894-1.144L.664 10.59zM10 15a4.5 4.5 0 100-9 4.5 4.5 0 000 9z" clip-rule="evenodd" />
+                <path
+                  fill-rule="evenodd"
+                  d="M.664 10.59a1.651 1.651 0 010-1.18l.879-1.528A1.65 1.65 0 013.437 7h13.126c1.062 0 1.92.714 2.248 1.754l.879 1.528a1.651 1.651 0 010 1.18l-.879 1.528A1.65 1.65 0 0116.563 13H3.437a1.65 1.65 0 01-1.894-1.144L.664 10.59zM10 15a4.5 4.5 0 100-9 4.5 4.5 0 000 9z"
+                  clip-rule="evenodd"
+                />
               </svg>
               <span>{{ item.views }} Views</span>
             </div>
             <span class="stat-separator">·</span>
             <div class="stat">
-              <svg class="stat-icon like-icon" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor">
-                <path fill-rule="evenodd" d="M3.172 5.172a4 4 0 015.656 0L10 6.343l1.172-1.171a4 4 0 115.656 5.656L10 17.657l-6.828-6.829a4 4 0 010-5.656z" clip-rule="evenodd" />
+              <svg
+                class="stat-icon like-icon"
+                xmlns="http://www.w3.org/2000/svg"
+                viewBox="0 0 20 20"
+                fill="currentColor"
+              >
+                <path
+                  fill-rule="evenodd"
+                  d="M3.172 5.172a4 4 0 015.656 0L10 6.343l1.172-1.171a4 4 0 115.656 5.656L10 17.657l-6.828-6.829a4 4 0 010-5.656z"
+                  clip-rule="evenodd"
+                />
               </svg>
               <span>{{ item.likes }} Likes</span>
             </div>
@@ -66,282 +67,189 @@
 </template>
 
 <script>
-export default {
-  name: 'GalleryPage',
-  data() {
-    return {
-      searchQuery: '',
-      galleryItems: [
-        {
-          image: 'https://images.unsplash.com/photo-1518005020951-eccb494ad742?q=80&w=1974',
-          title: 'Echoes of Silence',
-          author: 'Jane Smith',
-          description: '고요한 사막의 새벽, 빛과 그림자가 만들어내는 장엄한 순간을 포착했습니다. 자연의 위대함 앞에서 인간은 한없이 작아집니다.',
-          views: '15,742',
-          likes: '3,128'
-        },
-        {
-          image: 'https://images.unsplash.com/photo-1506905925346-21bda4d32df4?q=80&w=2070',
-          title: 'Urban Dreams',
-          author: 'Mike Johnson',
-          description: '도시의 밤, 네온사인이 만들어내는 환상적인 빛의 향연. 현대 문명의 아름다움과 고독함을 동시에 담았습니다.',
-          views: '12,456',
-          likes: '2,891'
-        },
-        {
-          image: 'https://images.unsplash.com/photo-1472214103451-9374bd1c798e?q=80&w=2070',
-          title: 'Ocean\'s Whisper',
-          author: 'Sarah Wilson',
-          description: '파도가 모래사장에 부서지는 순간의 평온함. 바다가 들려주는 영원한 이야기를 사진 한 장에 담았습니다.',
-          views: '18,923',
-          likes: '4,567'
-        }
-      ]
+  import AppHeader from './Header.vue'
+
+  export default {
+    name: 'GalleryPage',
+    components: {
+      AppHeader
+    },
+    data() {
+      return {
+        galleryItems: [
+          {
+            image:
+              'https://images.unsplash.com/photo-1518005020951-eccb494ad742?q=80&w=1974',
+            title: 'Echoes of Silence',
+            author: 'Jane Smith',
+            description:
+              '고요한 사막의 새벽, 빛과 그림자가 만들어내는 장엄한 순간을 포착했습니다. 자연의 위대함 앞에서 인간은 한없이 작아집니다.',
+            views: '15,742',
+            likes: '3,128'
+          },
+          {
+            image:
+              'https://images.unsplash.com/photo-1506905925346-21bda4d32df4?q=80&w=2070',
+            title: 'Urban Dreams',
+            author: 'Mike Johnson',
+            description:
+              '도시의 밤, 네온사인이 만들어내는 환상적인 빛의 향연. 현대 문명의 아름다움과 고독함을 동시에 담았습니다.',
+            views: '12,456',
+            likes: '2,891'
+          },
+          {
+            image:
+              'https://images.unsplash.com/photo-1472214103451-9374bd1c798e?q=80&w=2070',
+            title: "Ocean's Whisper",
+            author: 'Sarah Wilson',
+            description:
+              '파도가 모래사장에 부서지는 순간의 평온함. 바다가 들려주는 영원한 이야기를 사진 한 장에 담았습니다.',
+            views: '18,923',
+            likes: '4,567'
+          }
+        ]
+      }
+    },
+    methods: {
+      handleNavigate(page) {
+        this.$emit('navigate', page)
+      },
+      handleSearch(query) {
+        // 검색 로직 구현
+        console.log('Search query:', query)
+      }
     }
   }
-}
 </script>
 
 <style scoped>
-.gallery-page {
-  min-height: 100vh;
-  background-color: #111827;
-}
-
-.header {
-  position: sticky;
-  top: 0;
-  background-color: rgba(17, 24, 39, 0.8);
-  backdrop-filter: blur(16px);
-  z-index: 20;
-  border-bottom: 1px solid #374151;
-}
-
-.header-container {
-  max-width: 1200px;
-  margin: 0 auto;
-  padding: 0.75rem 1rem;
-  display: flex;
-  justify-content: space-between;
-  align-items: center;
-}
-
-.logo {
-  font-size: 1.5rem;
-  font-weight: bold;
-  color: #f59e0b;
-  font-family: 'Times New Roman', serif;
-  background: none;
-  border: none;
-  cursor: pointer;
-}
-
-.search-container {
-  position: relative;
-  width: 100%;
-  max-width: 24rem;
-}
-
-.search-input {
-  width: 100%;
-  padding: 0.5rem 0.75rem 0.5rem 2.5rem;
-  background-color: #1f2937;
-  border-radius: 9999px;
-  color: white;
-  border: none;
-}
-
-.search-input::placeholder {
-  color: #6b7280;
-}
-
-.search-input:focus {
-  outline: none;
-  box-shadow: 0 0 0 2px #f59e0b;
-}
-
-.search-icon {
-  width: 1.25rem;
-  height: 1.25rem;
-  position: absolute;
-  left: 0.75rem;
-  top: 50%;
-  transform: translateY(-50%);
-  color: #6b7280;
-}
-
-.nav-buttons {
-  display: flex;
-  align-items: center;
-  gap: 1rem;
-}
-
-.nav-btn {
-  color: #d1d5db;
-  background: none;
-  border: none;
-  cursor: pointer;
-  font-weight: 600;
-  transition: color 0.3s ease;
-}
-
-.nav-btn:hover, .nav-btn.active {
-  color: #f59e0b;
-}
-
-.profile-btn {
-  background: none;
-  border: none;
-  cursor: pointer;
-}
-
-.profile-img {
-  width: 2.5rem;
-  height: 2.5rem;
-  border-radius: 50%;
-  border: 2px solid #374151;
-  transition: border-color 0.3s ease;
-}
-
-.profile-img:hover {
-  border-color: #f59e0b;
-}
-
-.main-content {
-  max-width: 1200px;
-  margin: 0 auto;
-  padding: 1rem 1rem 2rem;
-}
-
-.gallery-intro {
-  text-align: center;
-  margin-bottom: 3rem;
-}
-
-.gallery-title {
-  font-size: 2.5rem;
-  font-weight: bold;
-  color: #f59e0b;
-  margin-bottom: 0.5rem;
-  font-family: 'Times New Roman', serif;
-}
-
-.gallery-subtitle {
-  color: #9ca3af;
-}
-
-.gallery-item {
-  background-color: #1f2937;
-  border-radius: 1rem;
-  box-shadow: 0 10px 15px -3px rgba(0, 0, 0, 0.1);
-  overflow: hidden;
-  margin-bottom: 2rem;
-  display: flex;
-  flex-direction: column;
-}
-
-.gallery-image {
-  flex: 1;
-}
-
-.gallery-photo {
-  width: 100%;
-  height: 400px;
-  object-fit: cover;
-}
-
-.gallery-content {
-  padding: 2rem;
-  display: flex;
-  flex-direction: column;
-  justify-content: center;
-}
-
-.item-title {
-  font-size: 1.875rem;
-  font-weight: bold;
-  margin-bottom: 0.5rem;
-}
-
-.item-author {
-  color: #f59e0b;
-  margin-bottom: 1rem;
-}
-
-.item-description {
-  color: #d1d5db;
-  margin-bottom: 1.5rem;
-  line-height: 1.6;
-}
-
-.item-stats {
-  display: flex;
-  align-items: center;
-  color: #9ca3af;
-  font-size: 0.875rem;
-}
-
-.stat {
-  display: flex;
-  align-items: center;
-}
-
-.stat-icon {
-  width: 1.25rem;
-  height: 1.25rem;
-  margin-right: 0.375rem;
-}
-
-.like-icon {
-  color: #ef4444;
-}
-
-.stat-separator {
-  margin: 0 0.5rem;
-}
-
-@media (min-width: 768px) {
-  .gallery-item {
-    flex-direction: row;
+  .gallery-page {
+    min-height: 100vh;
+    background-color: #111827;
   }
-  
-  .gallery-image {
-    width: 50%;
-  }
-  
-  .gallery-content {
-    width: 50%;
-  }
-  
-  .gallery-photo {
-    height: 100%;
-  }
-}
 
-@media (max-width: 768px) {
-  .header-container {
-    flex-direction: column;
-    gap: 1rem;
+  .main-content {
+    max-width: 1200px;
+    margin: 0 auto;
+    padding: 1rem 1rem 2rem;
   }
-  
-  .search-container {
-    order: 2;
+
+  .gallery-intro {
+    text-align: center;
+    margin-bottom: 3rem;
   }
-  
-  .nav-buttons {
-    order: 1;
-  }
-  
+
   .gallery-title {
-    font-size: 2rem;
+    font-size: 2.5rem;
+    font-weight: bold;
+    color: #f59e0b;
+    margin-bottom: 0.5rem;
+    font-family: 'Times New Roman', serif;
   }
-  
+
+  .gallery-subtitle {
+    color: #9ca3af;
+  }
+
+  .gallery-item {
+    background-color: #1f2937;
+    border-radius: 1rem;
+    box-shadow: 0 10px 15px -3px rgba(0, 0, 0, 0.1);
+    overflow: hidden;
+    margin-bottom: 2rem;
+    display: flex;
+    flex-direction: column;
+  }
+
+  .gallery-image {
+    flex: 1;
+  }
+
+  .gallery-photo {
+    width: 100%;
+    height: 400px;
+    object-fit: cover;
+  }
+
   .gallery-content {
-    padding: 1.5rem;
+    padding: 2rem;
+    display: flex;
+    flex-direction: column;
+    justify-content: center;
   }
-  
+
   .item-title {
-    font-size: 1.5rem;
+    font-size: 1.875rem;
+    font-weight: bold;
+    margin-bottom: 0.5rem;
   }
-}
+
+  .item-author {
+    color: #f59e0b;
+    margin-bottom: 1rem;
+  }
+
+  .item-description {
+    color: #d1d5db;
+    margin-bottom: 1.5rem;
+    line-height: 1.6;
+  }
+
+  .item-stats {
+    display: flex;
+    align-items: center;
+    color: #9ca3af;
+    font-size: 0.875rem;
+  }
+
+  .stat {
+    display: flex;
+    align-items: center;
+  }
+
+  .stat-icon {
+    width: 1.25rem;
+    height: 1.25rem;
+    margin-right: 0.375rem;
+  }
+
+  .like-icon {
+    color: #ef4444;
+  }
+
+  .stat-separator {
+    margin: 0 0.5rem;
+  }
+
+  @media (min-width: 768px) {
+    .gallery-item {
+      flex-direction: row;
+    }
+
+    .gallery-image {
+      width: 50%;
+    }
+
+    .gallery-content {
+      width: 50%;
+    }
+
+    .gallery-photo {
+      height: 100%;
+    }
+  }
+
+  @media (max-width: 768px) {
+    .gallery-title {
+      font-size: 2rem;
+    }
+
+    .gallery-content {
+      padding: 1.5rem;
+    }
+
+    .item-title {
+      font-size: 1.5rem;
+    }
+  }
 </style>

--- a/src/components/GalleryPage.vue
+++ b/src/components/GalleryPage.vue
@@ -2,7 +2,7 @@
   <div class="gallery-page">
     <!-- Header -->
     <AppHeader
-      :currentPage="'gallery'"
+      currentPage="gallery"
       @navigate="handleNavigate"
       @search="handleSearch"
     />

--- a/src/components/Header.vue
+++ b/src/components/Header.vue
@@ -1,0 +1,180 @@
+<template>
+  <header class="header">
+    <div class="header-container">
+      <button @click="$emit('navigate', 'feed')" class="logo">Picstory</button>
+      <div v-if="currentPage === 'feed'" class="search-container">
+        <input
+          type="search"
+          placeholder="검색..."
+          v-model="searchQuery"
+          class="search-input"
+          @input="$emit('search', searchQuery)"
+        />
+        <svg
+          class="search-icon"
+          xmlns="http://www.w3.org/2000/svg"
+          fill="none"
+          viewBox="0 0 24 24"
+          stroke="currentColor"
+        >
+          <path
+            stroke-linecap="round"
+            stroke-linejoin="round"
+            stroke-width="2"
+            d="M21 21l-6-6m2-5a7 7 0 11-14 0 7 7 0z"
+          ></path>
+        </svg>
+      </div>
+      <div class="nav-buttons">
+        <button
+          @click="$emit('navigate', 'gallery')"
+          class="nav-btn"
+          :class="{ active: currentPage === 'gallery' }"
+        >
+          Gallery
+        </button>
+        <button @click="$emit('navigate', 'profile')" class="profile-btn">
+          <img
+            src="https://placehold.co/40x40/334155/FFFFFF?text=Me"
+            class="profile-img"
+            alt="Profile"
+          />
+        </button>
+      </div>
+    </div>
+  </header>
+</template>
+
+<script>
+  export default {
+    name: 'AppHeader',
+    props: {
+      currentPage: {
+        type: String,
+        default: ''
+      }
+    },
+    data() {
+      return {
+        searchQuery: ''
+      }
+    }
+  }
+</script>
+
+<style scoped>
+  .header {
+    position: sticky;
+    top: 0;
+    background-color: rgba(17, 24, 39, 0.8);
+    backdrop-filter: blur(16px);
+    z-index: 20;
+    border-bottom: 1px solid #374151;
+  }
+
+  .header-container {
+    max-width: 1200px;
+    margin: 0 auto;
+    padding: 0.75rem 1rem;
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+  }
+
+  .logo {
+    font-size: 1.5rem;
+    font-weight: bold;
+    color: #f59e0b;
+    font-family: 'Times New Roman', serif;
+    background: none;
+    border: none;
+    cursor: pointer;
+  }
+
+  .search-container {
+    position: relative;
+    width: 100%;
+    max-width: 24rem;
+  }
+
+  .search-input {
+    width: 100%;
+    padding: 0.5rem 0.75rem 0.5rem 2.5rem;
+    background-color: #1f2937;
+    border-radius: 9999px;
+    color: white;
+    border: none;
+  }
+
+  .search-input::placeholder {
+    color: #6b7280;
+  }
+
+  .search-input:focus {
+    outline: none;
+    box-shadow: 0 0 0 2px #f59e0b;
+  }
+
+  .search-icon {
+    width: 1.25rem;
+    height: 1.25rem;
+    position: absolute;
+    left: 0.75rem;
+    top: 50%;
+    transform: translateY(-50%);
+    color: #6b7280;
+  }
+
+  .nav-buttons {
+    display: flex;
+    align-items: center;
+    gap: 1rem;
+  }
+
+  .nav-btn {
+    color: #d1d5db;
+    background: none;
+    border: none;
+    cursor: pointer;
+    font-weight: 600;
+    transition: color 0.3s ease;
+  }
+
+  .nav-btn:hover,
+  .nav-btn.active {
+    color: #f59e0b;
+  }
+
+  .profile-btn {
+    background: none;
+    border: none;
+    cursor: pointer;
+  }
+
+  .profile-img {
+    width: 2.5rem;
+    height: 2.5rem;
+    border-radius: 50%;
+    border: 2px solid #374151;
+    transition: border-color 0.3s ease;
+  }
+
+  .profile-img:hover {
+    border-color: #f59e0b;
+  }
+
+  @media (max-width: 768px) {
+    .header-container {
+      flex-direction: column;
+      gap: 1rem;
+    }
+
+    .search-container {
+      order: 2;
+    }
+
+    .nav-buttons {
+      order: 1;
+    }
+  }
+</style>

--- a/src/components/Header.vue
+++ b/src/components/Header.vue
@@ -166,7 +166,7 @@
     width: 2.5rem;
     height: 2.5rem;
     border-radius: 50%;
-    border: 2px solid #513737;
+    border: 2px solid #374151;
     transition: border-color 0.3s ease;
   }
 

--- a/src/components/Header.vue
+++ b/src/components/Header.vue
@@ -23,7 +23,7 @@
             stroke-linecap="round"
             stroke-linejoin="round"
             stroke-width="2"
-            d="M21 21l-6-6m2-5a7 7 0 11-14 0 7 7 0z"
+            d="m21 21-5.197-5.197m0 0A7.5 7.5 0 1 0 5.196 5.196a7.5 7.5 0 0 0 10.607 10.607Z"
           ></path>
         </svg>
       </div>
@@ -139,7 +139,7 @@
   .nav-buttons {
     display: flex;
     align-items: center;
-    gap: 1rem;
+    gap: 1.5rem;
   }
 
   .nav-btn {
@@ -166,7 +166,7 @@
     width: 2.5rem;
     height: 2.5rem;
     border-radius: 50%;
-    border: 2px solid #374151;
+    border: 2px solid #513737;
     transition: border-color 0.3s ease;
   }
 

--- a/src/components/Header.vue
+++ b/src/components/Header.vue
@@ -1,7 +1,9 @@
 <template>
   <header class="header">
     <div class="header-container">
-      <button @click="$emit('navigate', 'feed')" class="logo">Picstory</button>
+      <button @click="$emit('navigate', 'feed')" class="logo">
+        <img src="@/assets/logo.png" alt="Picstory" class="logo-img" />
+      </button>
       <div v-if="currentPage === 'feed'" class="search-container">
         <input
           type="search"
@@ -82,13 +84,22 @@
   }
 
   .logo {
-    font-size: 1.5rem;
-    font-weight: bold;
-    color: #f59e0b;
-    font-family: 'Times New Roman', serif;
     background: none;
     border: none;
     cursor: pointer;
+    padding: 0;
+    display: flex;
+    align-items: center;
+  }
+
+  .logo-img {
+    height: 2.5rem;
+    width: auto;
+    transition: opacity 0.3s ease;
+  }
+
+  .logo:hover .logo-img {
+    opacity: 0.8;
   }
 
   .search-container {

--- a/src/components/ProfilePage.vue
+++ b/src/components/ProfilePage.vue
@@ -2,7 +2,7 @@
   <div class="profile-page">
     <!-- Header -->
     <AppHeader
-      :currentPage="'profile'"
+      currentPage="profile"
       @navigate="handleNavigate"
       @search="handleSearch"
     />

--- a/src/components/ProfilePage.vue
+++ b/src/components/ProfilePage.vue
@@ -1,47 +1,34 @@
 <template>
   <div class="profile-page">
     <!-- Header -->
-    <header class="header">
-      <div class="header-container">
-        <button @click="$emit('navigate', 'feed')" class="logo">Picstory</button>
-        <div class="search-container">
-          <input 
-            type="search" 
-            placeholder="검색..." 
-            v-model="searchQuery"
-            class="search-input"
-          >
-          <svg class="search-icon" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M21 21l-6-6m2-5a7 7 0 11-14 0 7 7 0 0114 0z"></path>
-          </svg>
-        </div>
-        <div class="nav-buttons">
-          <button @click="$emit('navigate', 'gallery')" class="nav-btn">Gallery</button>
-          <button @click="$emit('navigate', 'profile')" class="profile-btn">
-            <img src="https://placehold.co/40x40/334155/FFFFFF?text=Me" class="profile-img" alt="Profile">
-          </button>
-        </div>
-      </div>
-    </header>
-    
+    <AppHeader
+      :currentPage="'profile'"
+      @navigate="handleNavigate"
+      @search="handleSearch"
+    />
+
     <main class="main-content">
       <!-- Profile Header -->
       <div class="profile-header">
-        <img src="https://placehold.co/128x128/334155/FFFFFF?text=Me" class="profile-avatar" alt="Profile">
+        <img
+          src="https://placehold.co/128x128/334155/FFFFFF?text=Me"
+          class="profile-avatar"
+          alt="Profile"
+        />
         <div class="profile-info">
           <h2 class="profile-name">Your Name</h2>
           <p class="profile-username">@yourusername</p>
           <div class="profile-stats">
             <div class="stat">
-              <span class="stat-number">128</span> 
+              <span class="stat-number">128</span>
               <span class="stat-label">Photos</span>
             </div>
             <div class="stat">
-              <span class="stat-number">1.2k</span> 
+              <span class="stat-number">1.2k</span>
               <span class="stat-label">Followers</span>
             </div>
             <div class="stat">
-              <span class="stat-number">340</span> 
+              <span class="stat-number">340</span>
               <span class="stat-label">Following</span>
             </div>
           </div>
@@ -52,13 +39,13 @@
       <!-- Uploaded Photos -->
       <h3 class="section-title">업로드한 사진</h3>
       <div class="photo-grid">
-        <div 
-          v-for="(image, index) in userImages" 
+        <div
+          v-for="(image, index) in userImages"
           :key="index"
           class="photo-item"
           @click="openImage(image, index)"
         >
-          <img :src="image.src" :alt="image.alt" class="photo">
+          <img :src="image.src" :alt="image.alt" class="photo" />
         </div>
       </div>
     </main>
@@ -66,284 +53,184 @@
 </template>
 
 <script>
-export default {
-  name: 'ProfilePage',
-  data() {
-    return {
-      searchQuery: '',
-      userImages: [
-        {
-          src: 'https://images.unsplash.com/photo-1444703686981-a3abbc4d4fe3?q=80&w=2070',
-          alt: '우주 사진',
-          title: 'Space Galaxy',
-          author: 'Your Name'
-        },
-        {
-          src: 'https://images.unsplash.com/photo-1451187580459-43490279c0fa?q=80&w=2072',
-          alt: '지구 사진',
-          title: 'Earth from Space',
-          author: 'Your Name'
-        },
-        {
-          src: 'https://images.unsplash.com/photo-1451187580459-43490279c0fa?q=80&w=2072',
-          alt: '지구 사진',
-          title: 'Blue Planet',
-          author: 'Your Name'
-        }
-      ]
-    }
-  },
-  methods: {
-    openImage(image, index) {
-      this.$emit('openModal', image, this.userImages, index)
+  import AppHeader from './Header.vue'
+
+  export default {
+    name: 'ProfilePage',
+    components: {
+      AppHeader
+    },
+    data() {
+      return {
+        userImages: [
+          {
+            src: 'https://images.unsplash.com/photo-1444703686981-a3abbc4d4fe3?q=80&w=2070',
+            alt: '우주 사진',
+            title: 'Space Galaxy',
+            author: 'Your Name'
+          },
+          {
+            src: 'https://images.unsplash.com/photo-1451187580459-43490279c0fa?q=80&w=2072',
+            alt: '지구 사진',
+            title: 'Earth from Space',
+            author: 'Your Name'
+          },
+          {
+            src: 'https://images.unsplash.com/photo-1451187580459-43490279c0fa?q=80&w=2072',
+            alt: '지구 사진',
+            title: 'Blue Planet',
+            author: 'Your Name'
+          }
+        ]
+      }
+    },
+    methods: {
+      openImage(image, index) {
+        this.$emit('openModal', image, this.userImages, index)
+      },
+      handleNavigate(page) {
+        this.$emit('navigate', page)
+      },
+      handleSearch(query) {
+        // 검색 로직 구현
+        console.log('Search query:', query)
+      }
     }
   }
-}
 </script>
 
 <style scoped>
-.profile-page {
-  min-height: 100vh;
-  background-color: #111827;
-}
+  .profile-page {
+    min-height: 100vh;
+    background-color: #111827;
+  }
 
-.header {
-  position: sticky;
-  top: 0;
-  background-color: rgba(17, 24, 39, 0.8);
-  backdrop-filter: blur(16px);
-  z-index: 20;
-  border-bottom: 1px solid #374151;
-}
+  .main-content {
+    max-width: 1200px;
+    margin: 0 auto;
+    padding: 1rem 1rem 2rem;
+  }
 
-.header-container {
-  max-width: 1200px;
-  margin: 0 auto;
-  padding: 0.75rem 1rem;
-  display: flex;
-  justify-content: space-between;
-  align-items: center;
-}
-
-.logo {
-  font-size: 1.5rem;
-  font-weight: bold;
-  color: #f59e0b;
-  font-family: 'Times New Roman', serif;
-  background: none;
-  border: none;
-  cursor: pointer;
-}
-
-.search-container {
-  position: relative;
-  width: 100%;
-  max-width: 24rem;
-}
-
-.search-input {
-  width: 100%;
-  padding: 0.5rem 0.75rem 0.5rem 2.5rem;
-  background-color: #1f2937;
-  border-radius: 9999px;
-  color: white;
-  border: none;
-}
-
-.search-input::placeholder {
-  color: #6b7280;
-}
-
-.search-input:focus {
-  outline: none;
-  box-shadow: 0 0 0 2px #f59e0b;
-}
-
-.search-icon {
-  width: 1.25rem;
-  height: 1.25rem;
-  position: absolute;
-  left: 0.75rem;
-  top: 50%;
-  transform: translateY(-50%);
-  color: #6b7280;
-}
-
-.nav-buttons {
-  display: flex;
-  align-items: center;
-  gap: 1rem;
-}
-
-.nav-btn {
-  color: #d1d5db;
-  background: none;
-  border: none;
-  cursor: pointer;
-  transition: color 0.3s ease;
-}
-
-.nav-btn:hover {
-  color: #f59e0b;
-}
-
-.profile-btn {
-  background: none;
-  border: none;
-  cursor: pointer;
-}
-
-.profile-img {
-  width: 2.5rem;
-  height: 2.5rem;
-  border-radius: 50%;
-  border: 2px solid #374151;
-  transition: border-color 0.3s ease;
-}
-
-.profile-img:hover {
-  border-color: #f59e0b;
-}
-
-.main-content {
-  max-width: 1200px;
-  margin: 0 auto;
-  padding: 1rem 1rem 2rem;
-}
-
-.profile-header {
-  display: flex;
-  flex-direction: column;
-  align-items: center;
-  text-align: center;
-  margin-bottom: 2rem;
-}
-
-.profile-avatar {
-  width: 8rem;
-  height: 8rem;
-  border-radius: 50%;
-  border: 4px solid #374151;
-  margin-bottom: 1rem;
-}
-
-.profile-info {
-  flex-grow: 1;
-}
-
-.profile-name {
-  font-size: 1.875rem;
-  font-weight: bold;
-  margin-bottom: 0.5rem;
-}
-
-.profile-username {
-  color: #9ca3af;
-  margin-bottom: 1rem;
-}
-
-.profile-stats {
-  display: flex;
-  justify-content: center;
-  gap: 1.5rem;
-  margin-bottom: 1rem;
-}
-
-.stat {
-  text-align: center;
-}
-
-.stat-number {
-  font-weight: bold;
-  font-size: 1.25rem;
-}
-
-.stat-label {
-  color: #9ca3af;
-  font-size: 0.875rem;
-}
-
-.edit-profile-btn {
-  padding: 0.5rem 1rem;
-  background-color: #374151;
-  color: white;
-  border: none;
-  border-radius: 0.5rem;
-  font-size: 0.875rem;
-  font-weight: 600;
-  cursor: pointer;
-  transition: background-color 0.3s ease;
-}
-
-.edit-profile-btn:hover {
-  background-color: #4b5563;
-}
-
-.section-title {
-  font-size: 1.25rem;
-  font-weight: bold;
-  margin-bottom: 1rem;
-}
-
-.photo-grid {
-  display: grid;
-  grid-template-columns: repeat(auto-fill, minmax(250px, 1fr));
-  gap: 1rem;
-}
-
-.photo-item {
-  cursor: pointer;
-  border-radius: 0.5rem;
-  overflow: hidden;
-  transition: transform 0.3s ease;
-}
-
-.photo-item:hover {
-  transform: scale(1.02);
-}
-
-.photo {
-  width: 100%;
-  height: 300px;
-  object-fit: cover;
-}
-
-@media (min-width: 768px) {
   .profile-header {
-    flex-direction: row;
-    text-align: left;
-    gap: 2rem;
-  }
-  
-  .profile-avatar {
-    margin-bottom: 0;
-  }
-  
-  .profile-stats {
-    justify-content: flex-start;
-  }
-}
-
-@media (max-width: 768px) {
-  .header-container {
+    display: flex;
     flex-direction: column;
+    align-items: center;
+    text-align: center;
+    margin-bottom: 2rem;
+  }
+
+  .profile-avatar {
+    width: 8rem;
+    height: 8rem;
+    border-radius: 50%;
+    border: 4px solid #374151;
+    margin-bottom: 1rem;
+  }
+
+  .profile-info {
+    flex-grow: 1;
+  }
+
+  .profile-name {
+    font-size: 1.875rem;
+    font-weight: bold;
+    margin-bottom: 0.5rem;
+  }
+
+  .profile-username {
+    color: #9ca3af;
+    margin-bottom: 1rem;
+  }
+
+  .profile-stats {
+    display: flex;
+    justify-content: center;
+    gap: 1.5rem;
+    margin-bottom: 1rem;
+  }
+
+  .stat {
+    text-align: center;
+  }
+
+  .stat-number {
+    font-weight: bold;
+    font-size: 1.25rem;
+  }
+
+  .stat-label {
+    color: #9ca3af;
+    font-size: 0.875rem;
+  }
+
+  .edit-profile-btn {
+    padding: 0.5rem 1rem;
+    background-color: #374151;
+    color: white;
+    border: none;
+    border-radius: 0.5rem;
+    font-size: 0.875rem;
+    font-weight: 600;
+    cursor: pointer;
+    transition: background-color 0.3s ease;
+  }
+
+  .edit-profile-btn:hover {
+    background-color: #4b5563;
+  }
+
+  .section-title {
+    font-size: 1.25rem;
+    font-weight: bold;
+    margin-bottom: 1rem;
+  }
+
+  .photo-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fill, minmax(250px, 1fr));
     gap: 1rem;
   }
-  
-  .search-container {
-    order: 2;
+
+  .photo-item {
+    cursor: pointer;
+    border-radius: 0.5rem;
+    overflow: hidden;
+    transition: transform 0.3s ease;
   }
-  
-  .nav-buttons {
-    order: 1;
+
+  .photo-item:hover {
+    transform: scale(1.02);
   }
-  
-  .photo-grid {
-    grid-template-columns: repeat(auto-fill, minmax(200px, 1fr));
-  }
-  
+
   .photo {
-    height: 200px;
+    width: 100%;
+    height: 300px;
+    object-fit: cover;
   }
-}
+
+  @media (min-width: 768px) {
+    .profile-header {
+      flex-direction: row;
+      text-align: left;
+      gap: 2rem;
+    }
+
+    .profile-avatar {
+      margin-bottom: 0;
+    }
+
+    .profile-stats {
+      justify-content: flex-start;
+    }
+  }
+
+  @media (max-width: 768px) {
+    .photo-grid {
+      grid-template-columns: repeat(auto-fill, minmax(200px, 1fr));
+    }
+
+    .photo {
+      height: 200px;
+    }
+  }
 </style>


### PR DESCRIPTION
This pull request introduces a reusable `AppHeader` component to standardize the header across multiple pages (`FeedPage`, `GalleryPage`, and `ProfilePage`). It removes redundant header-related code from individual pages and centralizes the logic in the new component. Additionally, it includes minor improvements to HTML formatting and styling.

### Header Refactoring:
* Replaced individual header implementations in `FeedPage`, `GalleryPage`, and `ProfilePage` with the new `AppHeader` component. The `AppHeader` now handles navigation and search functionality via `@navigate` and `@search` events.
* Removed all header-related styles and logic from the individual pages, including CSS classes like `.header`, `.header-container`, and `.search-container`. These are now encapsulated within the `AppHeader` component.
### Code Simplification:
* Imported the `AppHeader` component in `FeedPage`, `GalleryPage`, and `ProfilePage`. Registered it under `components` and passed the `currentPage` prop to indicate the active page.

### Minor Improvements:
* Standardized HTML formatting by closing self-closing tags properly (e.g., `<img />`, `<svg />`). 
* Improved readability of long strings in `GalleryPage` by breaking them into multiple lines.